### PR TITLE
Changes so that hardware cannot be accessed until after INIT is pressed

### DIFF
--- a/Controller/src/com/qualcomm/robotcore/hardware/HardwareMap.java
+++ b/Controller/src/com/qualcomm/robotcore/hardware/HardwareMap.java
@@ -77,7 +77,14 @@ public class HardwareMap implements Iterable<HardwareDevice>{
      */
     private List<HardwareDevice> allDevicesList = new ArrayList<>();
 
-    private final Object lock = new Object();
+    /**
+     * INTERNAL USE ONLY!!!
+     * This is needed to prevent users from obtaining hardware references before the INIT button is pressed.
+     * i.e., references to hardware should be obtained in the opmode.init(), opmode.loop(), or linearopmode.runopmode()
+     * methods.
+     */
+    private boolean active = false;
+    public void setActive(boolean isActive){ active = isActive; }
 
     /**
      * Add a device to the HardwareMap
@@ -117,6 +124,10 @@ public class HardwareMap implements Iterable<HardwareDevice>{
 
 
     private synchronized <T> T tryGet(Class<? extends T> classOrInterface, String deviceName){
+        if (!active){
+            System.out.println("ERROR: Cannot obtain references to hardware before INIT button is pressed.");
+            return null;
+        }
         deviceName = deviceName.trim();
         List<HardwareDevice> list = allDevicesMap.get(deviceName);
         if (list != null) {
@@ -184,6 +195,10 @@ public class HardwareMap implements Iterable<HardwareDevice>{
          * @return
          */
         public synchronized DEVICE_TYPE get(String deviceName){
+            if (!active){
+                System.out.println("ERROR: Cannot obtain references to hardware before INIT button is pressed.");
+                return null;
+            }
             deviceName = deviceName.trim();
             DEVICE_TYPE result = map.get(deviceName);
             if (result == null) throw new IllegalArgumentException(

--- a/Controller/src/virtual_robot/controller/VirtualRobotController.java
+++ b/Controller/src/virtual_robot/controller/VirtualRobotController.java
@@ -382,6 +382,7 @@ public class VirtualRobotController {
                 Thread.currentThread().interrupt();
             }
             if (opModeThread.isAlive()) System.out.println("OpMode Thread Failed to Terminate.");
+            bot.getHardwareMap().setActive(false);
             bot.powerDownAndReset();
             if (Config.USE_VIRTUAL_GAMEPAD) virtualGamePadController.resetGamePad();
             initializeTelemetryTextArea();
@@ -392,6 +393,10 @@ public class VirtualRobotController {
     private void runOpModeAndCleanUp(){
 
         try {
+            //Activate the hardware map, so that calls to "get" on the hardware map itself, and on dcMotor, etc,
+            //will return hardware objects
+            bot.getHardwareMap().setActive(true);
+
             //For regular opMode, run user-defined init() method. For Linear opMode, init() starts the execution of
             //runOpMode on a helper thread.
             opMode.init();
@@ -447,6 +452,7 @@ public class VirtualRobotController {
             System.out.println(e.getLocalizedMessage());
         }
 
+        bot.getHardwareMap().setActive(false);
         bot.powerDownAndReset();
         if (!executorService.isShutdown()) executorService.shutdown();
         opModeInitialized = false;

--- a/Controller/src/virtual_robot/controller/robots/classes/ArmBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/ArmBot.java
@@ -104,6 +104,9 @@ public class ArmBot extends VirtualBot {
         //createHardwareMap() method, so that a HardwareMap object will be available.
         super();
 
+        //Temporarily activate the hardware map to allow calls to "get"
+        hardwareMap.setActive(true);
+
         //Instantiate the DC Motors using the HardwareMap object. Note the cast to DcMotorImpl.
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class,"back_left_motor"),
@@ -146,6 +149,10 @@ public class ArmBot extends VirtualBot {
                 {-0.25/ WIDTH_LENGTH_AVERAGE, -0.25/ WIDTH_LENGTH_AVERAGE, 0.25/ WIDTH_LENGTH_AVERAGE, 0.25/ WIDTH_LENGTH_AVERAGE},
                 {-0.25, 0.25, 0.25, -0.25}
         };
+
+        //Deactivate the hardwaremap to prevent users from accessing hardware until after INIT is pressed
+        hardwareMap.setActive(false);
+
     }
 
     /**

--- a/Controller/src/virtual_robot/controller/robots/classes/EncoderBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/EncoderBot.java
@@ -64,6 +64,7 @@ public class EncoderBot extends VirtualBot {
 
     public EncoderBot(){
         super();
+        hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class,"back_left_motor"),
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class,"front_left_motor"),
@@ -99,6 +100,7 @@ public class EncoderBot extends VirtualBot {
                 {-0.25/ wlAverage, -0.25/ wlAverage, 0.25/ wlAverage, 0.25/ wlAverage},
                 {-0.25, 0.25, 0.25, -0.25}
         };
+        hardwareMap.setActive(false);
     }
 
     public void initialize(){

--- a/Controller/src/virtual_robot/controller/robots/classes/MechanumBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/MechanumBot.java
@@ -41,6 +41,7 @@ public class MechanumBot extends VirtualBot {
 
     public MechanumBot(){
         super();
+        hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "back_left_motor"),
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "front_left_motor"),
@@ -68,6 +69,7 @@ public class MechanumBot extends VirtualBot {
                 {-0.25/ wlAverage, -0.25/ wlAverage, 0.25/ wlAverage, 0.25/ wlAverage},
                 {-0.25, 0.25, 0.25, -0.25}
         };
+        hardwareMap.setActive(false);
     }
 
     public void initialize(){

--- a/Controller/src/virtual_robot/controller/robots/classes/TwoWheelBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/TwoWheelBot.java
@@ -36,6 +36,7 @@ public class TwoWheelBot extends VirtualBot {
 
     public TwoWheelBot(){
         super();
+        hardwareMap.setActive(true);
         leftMotor = (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "left_motor");
         rightMotor = (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "right_motor");
         distanceSensors = new VirtualRobotController.DistanceSensorImpl[]{
@@ -49,6 +50,7 @@ public class TwoWheelBot extends VirtualBot {
         servo = (ServoImpl)hardwareMap.servo.get("back_servo");
         wheelCircumference = Math.PI * botWidth / 4.5;
         interWheelDistance = botWidth * 8.0 / 9.0;
+        hardwareMap.setActive(false);
     }
 
     public void initialize(){

--- a/Controller/src/virtual_robot/controller/robots/classes/XDriveBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/XDriveBot.java
@@ -39,6 +39,7 @@ public class XDriveBot extends VirtualBot {
 
     public XDriveBot() {
         super();
+        hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "back_left_motor"),
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "front_left_motor"),
@@ -65,6 +66,7 @@ public class XDriveBot extends VirtualBot {
                 {-0.25/ wheelBaseRadius, -0.25/ wheelBaseRadius, 0.25/ wheelBaseRadius, 0.25/ wheelBaseRadius},
                 {-0.25, 0.25, 0.25, -0.25}
         };
+        hardwareMap.setActive(false);
     }
 
     public void initialize(){


### PR DESCRIPTION
For greater adherence to behavior of the FTC control system, it should not be possible to obtain references to hardware before the INIT button is pressed (so, calls to hardwareMap.get, hardwareMap.dcMotor.get, etc, should not work).

With this change, attempts to obtain hardware references will result in an error message, and return of a null object. This ultimately will result in an exception, and the op mode will exit.