### PR TITLE
Changed to match FTC SDK behavior for Teleop() and Autonomous()

### DIFF
--- a/Controller/src/com/qualcomm/robotcore/eventloop/opmode/Autonomous.java
+++ b/Controller/src/com/qualcomm/robotcore/eventloop/opmode/Autonomous.java
@@ -37,18 +37,39 @@ Modified by FTC Team Beta 8397 for use in the Virtual_Robot Simulator
 
 package com.qualcomm.robotcore.eventloop.opmode;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Op Mode classes must be annotated with either Autonomous or TeleOp in order to be displayed in the dropdown box
- * of available op modes.
+ * Provides an easy and non-centralized way of determining the OpMode list
+ * shown on an FTC Driver Station.  Put an {@link Autonomous} annotation on
+ * your autonomous OpModes that you want to show up in the driver station display.
+ *
+ * If you want to temporarily disable an opmode, then set then also add
+ * a {@link Disabled} annotation to it.
+ *
+ * @see TeleOp
+ * @see Disabled
  */
+@Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Autonomous {
-    String name();
-    String group() default "default";
+public @interface Autonomous
+{
+    /**
+     * The name to be used on the driver station display. If empty, the name of
+     * the OpMode class will be used.
+     * @return the name to use for the OpMode in the driver station.
+     */
+    String name() default "";
+
+    /**
+     * Optionally indicates a group of other OpModes with which the annotated
+     * OpMode should be sorted on the driver station OpMode list.
+     * @return the group into which the annotated OpMode is to be categorized
+     */
+    String group() default "";
 }

--- a/Controller/src/com/qualcomm/robotcore/eventloop/opmode/TeleOp.java
+++ b/Controller/src/com/qualcomm/robotcore/eventloop/opmode/TeleOp.java
@@ -37,18 +37,39 @@ Modified by FTC Team Beta 8397 for use in the Virtual_Robot Simulator
 
 package com.qualcomm.robotcore.eventloop.opmode;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Op Mode classes must be annotated with either Autonomous or TeleOp in order to be displayed in the dropdown box
- * of available op modes.
+ * Provides an easy and non-centralized way of determining the OpMode list
+ * shown on an FTC Driver Station.  Put an {@link TeleOp} annotation on
+ * your teleop OpModes that you want to show up in the driver station display.
+ *
+ * If you want to temporarily disable an opmode from showing up, then set then also add
+ * a {@link Disabled} annotation to it.
+ *
+ * @see Autonomous
+ * @see Disabled
  */
+@Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface TeleOp {
-    String name();
-    String group() default "default";
+public @interface TeleOp
+{
+    /**
+     * The name to be used on the driver station display. If empty, the name of
+     * the OpMode class will be used.
+     * @return the name to use for the OpMode on the driver station
+     */
+    String name() default "";
+
+    /**
+     * Optionally indicates a group of other OpModes with which the annotated
+     * OpMode should be sorted on the driver station OpMode list.
+     * @return the group into which the annotated OpMode is to be categorized
+     */
+    String group() default "";
 }

--- a/Controller/src/virtual_robot/controller/VirtualRobotController.java
+++ b/Controller/src/virtual_robot/controller/VirtualRobotController.java
@@ -262,6 +262,36 @@ public class VirtualRobotController {
         }
     }
 
+    private String getNameFromAnnotationOrOpmode(Class c){
+        String name = "";
+        Annotation a1 = c.getAnnotation(TeleOp.class);
+        if(a1 != null){
+            name = ((TeleOp)a1).name();
+        }else{
+            a1 = c.getAnnotation(Autonomous.class);
+            if(a1 != null){
+                name = ((Autonomous)a1).name();
+            }
+        }
+        if(name.isEmpty()){
+            name = c.getSimpleName();
+        }
+        return name;
+    }
+    private String getGroupFromAnnotationOrOpmode(Class c){
+        String group = null;
+        Annotation a1 = c.getAnnotation(TeleOp.class);
+        if(a1 != null){
+            group = ((TeleOp)a1).group();
+        }else{
+            a1 = c.getAnnotation(Autonomous.class);
+            if(a1 != null){
+                group = ((Autonomous)a1).group();
+            }
+        }
+        return group;
+    }
+
     private void setupCbxOpModes(){
         //Reflections reflections = new Reflections(VirtualRobotApplication.class.getClassLoader());
         Reflections reflections = new Reflections("org.firstinspires.ftc.teamcode");
@@ -278,21 +308,8 @@ public class VirtualRobotController {
         nonDisabledOpModeClasses.sort(new Comparator<Class<?>>() {
             @Override
             public int compare(Class<?> o1, Class<?> o2) {
-                String group1 = null;
-                Annotation a1 = o1.getAnnotation(TeleOp.class);
-                if (a1 != null) group1 = ((TeleOp)a1).group();
-                else{
-                    a1 = o1.getAnnotation(Autonomous.class);
-                    if (a1 != null) group1 = ((Autonomous)a1).group();
-                }
-
-                String group2 = null;
-                Annotation a2 = o2.getAnnotation(TeleOp.class);
-                if (a2 != null) group2 = ((TeleOp)a2).group();
-                else{
-                    a2 = o2.getAnnotation(Autonomous.class);
-                    if (a2 != null) group2 = ((Autonomous)a2).group();
-                }
+                String group1 = getGroupFromAnnotationOrOpmode(o1);
+                String group2 = getGroupFromAnnotationOrOpmode(o2);
 
                 if (group1 == null) return -1;
                 else if (group2 == null) return 1;
@@ -313,14 +330,14 @@ public class VirtualRobotController {
                             setText(null);
                             return;
                         }
-                        Annotation a = cl.getAnnotation(TeleOp.class);
-                        if (a != null) setText(((TeleOp)a).group() + ": " + ((TeleOp)a).name());
-                        else {
-                            a = cl.getAnnotation(Autonomous.class);
-                            if (a != null) setText(((Autonomous)a).group() + ": "  + ((Autonomous)a).name());
-                            else setText("No Name");
-                        }
+                        String group = getGroupFromAnnotationOrOpmode(cl);
+                        String name = getNameFromAnnotationOrOpmode(cl);
 
+                        if(group.isEmpty()) {
+                            setText(name);
+                        }else{
+                            setText(group + ": " + name);
+                        }
                     }
                 };
                 return cell;
@@ -335,13 +352,7 @@ public class VirtualRobotController {
                     setText(null);
                     return;
                 }
-                Annotation a = cl.getAnnotation(TeleOp.class);
-                if (a != null) setText(((TeleOp) a).name());
-                else {
-                    a = cl.getAnnotation(Autonomous.class);
-                    if (a != null) setText(((Autonomous) a).name());
-                    else setText("No Name");
-                }
+                setText(getNameFromAnnotationOrOpmode(cl));
             }
         });
 


### PR DESCRIPTION
Teleop() and Autonomous() required a name but in the FTC SDK they do not.
Changed the simulator to act like the FTC SDK.
