### PR TITLE
'remove(...)' methods added to HardwareMap and DeviceMapping. Reorganized robot configuration setup code.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
   <component name="ProjectKey">
     <option name="state" value="project://e79810c8-c5c8-43b1-b19c-90c1f4095425" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8 (2)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
   <component name="ProjectKey">
     <option name="state" value="project://e79810c8-c5c8-43b1-b19c-90c1f4095425" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8 (2)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/Controller/src/com/qualcomm/robotcore/hardware/HardwareMap.java
+++ b/Controller/src/com/qualcomm/robotcore/hardware/HardwareMap.java
@@ -120,22 +120,17 @@ public class HardwareMap implements Iterable<HardwareDevice>{
      * @return whether a device was removed or not
      */
     public boolean remove(String deviceName, HardwareDevice device) {
-            deviceName = deviceName.trim();
-            List<HardwareDevice> list = allDevicesMap.get(deviceName);
-            if (list != null) {
-                list.remove(device);
-                if (list.isEmpty()) {
-                    allDevicesMap.remove(deviceName);
-                }
-                //allDevicesList = null;
-                /*deviceNames = null;
-                if (serialNumber != null) {
-                    serialNumberMap.remove(serialNumber);
-                }
-                 */
-                return true;
+        deviceName = deviceName.trim();
+        List<HardwareDevice> list = allDevicesMap.get(deviceName);
+        if (list != null) {
+            list.remove(device);
+            if (list.isEmpty()) {
+                allDevicesMap.remove(deviceName);
             }
-            return false;
+            allDevicesList.remove(device);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -246,6 +241,27 @@ public class HardwareMap implements Iterable<HardwareDevice>{
         public synchronized void put(String deviceName, DEVICE_TYPE device){
             deviceName = deviceName.trim();
             map.put(deviceName, device);
+        }
+
+        /**
+         * FOR INTERNAL USE ONLY
+         *
+         * (Advanced) Removes the device with the indicated name (if any) from this DeviceMapping. The device
+         * is also removed under that name in the overall map itself. Note that this method is normally
+         * called only by code in the SDK itself, not by user code.
+         *
+         * @param deviceName the name of the device to remove.
+         * @return whether any modifications were made to this DeviceMapping
+         * @see HardwareMap#remove
+         */
+        public synchronized boolean remove(String deviceName) {
+            deviceName = deviceName.trim();
+            HardwareDevice device = map.remove(deviceName);
+            if (device != null) {
+                HardwareMap.this.remove(deviceName, device);
+                return true;
+            }
+            return false;
         }
 
         /**

--- a/Controller/src/virtual_robot/controller/VirtualBot.java
+++ b/Controller/src/virtual_robot/controller/VirtualBot.java
@@ -67,7 +67,6 @@ public abstract class VirtualBot {
 
     public VirtualBot(){
         fieldPane = controller.getFieldPane();
-        createHardwareMap();
         this.fieldWidth = fieldPane.getPrefWidth();
         halfFieldWidth = fieldWidth / 2.0;
         botWidth = fieldWidth / 8.0;
@@ -76,6 +75,14 @@ public abstract class VirtualBot {
         X_MAX = 2.0 * (Config.X_MAX_FRACTION - 0.5) * halfFieldWidth;
         Y_MIN = 2.0 * (Config.Y_MIN_FRACTION - 0.5) * halfFieldWidth;
         Y_MAX = 2.0 * (Config.Y_MAX_FRACTION - 0.5) * halfFieldWidth;
+    }
+
+    /**
+     * Create the HardwareMap.  Classes extending VirtualBot must have an 'initialize' method which has
+     * as its first statement 'super.init()'
+     */
+    public void initialize(){
+        createHardwareMap();
     }
 
     static void setController(VirtualRobotController ctrl){

--- a/Controller/src/virtual_robot/controller/robots/classes/ArmBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/ArmBot.java
@@ -63,10 +63,19 @@ public class ArmBot extends MechanumBase {
      * Constructor.
      */
     public ArmBot() {
-
-        //This call to the superclass constructor is essential. Among other things, this will call the
-        //createHardwareMap() method, so that a HardwareMap object will be available.
         super();
+    }
+
+    /**
+     *  The initialize() method is called automatically when the robot's graphical UI is loaded from the
+     *  arm_bot.fxml markup file. It should be used to set up parts of the graphical UI that will change
+     *  as the robot operates
+     */
+    public void initialize(){
+        //This call to the superclass initialize method is essential. Among other things, this will call the
+        //createHardwareMap() method, so that a HardwareMap object will be available. It also does all of
+        //the initialization of the Mechanum drive base.
+        super.initialize();
 
         //Temporarily activate the hardware map to allow calls to "get"
         hardwareMap.setActive(true);
@@ -79,14 +88,6 @@ public class ArmBot extends MechanumBase {
         //Deactivate the hardwaremap to prevent users from accessing hardware until after INIT is pressed
         hardwareMap.setActive(false);
 
-    }
-
-    /**
-     *  The initialize() method is called automatically when the robot's graphical UI is loaded from the
-     *  arm_bot.fxml markup file. It should be used to set up parts of the graphical UI that will change
-     *  as the robot operates
-     */
-    public void initialize(){
         /*
         Scales the arm with pivot point at center of back of robot (which corresponds to the back of the arm).
         The Y-scaling is initialized to 1.0 (i.e., arm fully retracted)

--- a/Controller/src/virtual_robot/controller/robots/classes/DiffSwerveBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/DiffSwerveBot.java
@@ -22,7 +22,7 @@ import virtual_robot.util.Vector2D;
 @BotConfig(name = "Differential Swerve Bot", filename = "diff_swerve_bot")
 public class DiffSwerveBot extends VirtualBot {
 
-    MotorType motorType;
+    private final MotorType MOTOR_TYPE = MotorType.NeverestOrbital20;
     private DcMotorExImpl[] motors = null;
     private BNO055IMUImpl imu = null;
     private VirtualRobotController.ColorSensorImpl colorSensor = null;
@@ -57,6 +57,10 @@ public class DiffSwerveBot extends VirtualBot {
 
     public DiffSwerveBot(){
         super();
+    }
+
+    public void initialize() {
+        super.initialize();
         hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "bottom_left_motor"),
@@ -80,17 +84,13 @@ public class DiffSwerveBot extends VirtualBot {
         WHEEL_POS[1] = new Vector2D(interWheelWidth/2, 0);          //Right
 
         hardwareMap.setActive(false);
-    }
-
-    public void initialize(){
         backServoArm.getTransforms().add(new Rotate(0, 37.5, 67.5));
     }
 
     protected void createHardwareMap(){
-        motorType = MotorType.NeverestOrbital20;
         hardwareMap = new HardwareMap();
         String[] motorNames = new String[] {"bottom_left_motor", "top_left_motor", "bottom_right_motor", "top_right_motor"};
-        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(motorType));
+        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(MOTOR_TYPE));
         String[] distNames = new String[]{"front_distance", "left_distance", "back_distance", "right_distance"};
         for (String name: distNames) hardwareMap.put(name, controller.new DistanceSensorImpl());
         hardwareMap.put("imu", new BNO055IMUImpl(this, 10));
@@ -126,9 +126,9 @@ public class DiffSwerveBot extends VirtualBot {
 //            double steerTicks = (deltaPosBottom + deltaPosTop) / 2.0;
             double driveTicks = (deltaPosBottom - deltaPosTop) / 2.0;
             steer[i] = -Math.PI * (motors[2*i].getActualPosition() + motors[2*i+1].getActualPosition())
-                    / (STEER_RATIO * motorType.TICKS_PER_ROTATION);
+                    / (STEER_RATIO * MOTOR_TYPE.TICKS_PER_ROTATION);
 //            steer[i] -= 2.0 * Math.PI * steerTicks / (STEER_RATIO * MOTOR_TYPE.TICKS_PER_ROTATION);
-            double s = driveTicks * wheelCircumference /(DRIVE_RATIO * motorType.TICKS_PER_ROTATION);
+            double s = driveTicks * wheelCircumference /(DRIVE_RATIO * MOTOR_TYPE.TICKS_PER_ROTATION);
             if (i == 1) s = -s;
             Vector2D w = new Vector2D(-s * Math.sin(steer[i]+headingRadians), s * Math.cos(steer[i]+headingRadians));
             Vector2D v = velocity.added(WHEEL_POS[i].rotated(headingRadians+Math.PI/2).multiplied(omega));

--- a/Controller/src/virtual_robot/controller/robots/classes/EncoderBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/EncoderBot.java
@@ -21,7 +21,7 @@ import virtual_robot.util.AngleUtils;
 @BotConfig(name = "Encoder Bot", filename = "encoder_bot")
 public class EncoderBot extends VirtualBot {
 
-    MotorType motorType;
+    MotorType MOTOR_TYPE = MotorType.Neverest40;
     MotorType encoderMotorType;
     private DcMotorExImpl[] motors = null;
     //private VirtualRobotController.GyroSensorImpl gyro = null;
@@ -65,6 +65,10 @@ public class EncoderBot extends VirtualBot {
 
     public EncoderBot(){
         super();
+    }
+
+    public void initialize(){
+        super.initialize();
         hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class,"back_left_motor"),
@@ -102,19 +106,14 @@ public class EncoderBot extends VirtualBot {
                 {-0.25, 0.25, 0.25, -0.25}
         };
         hardwareMap.setActive(false);
-    }
-
-    public void initialize(){
-        //backServoArm = (Rectangle)displayGroup.getChildren().get(8);
         backServoArm.getTransforms().add(new Rotate(0, 37.5, 67.5));
     }
 
     protected void createHardwareMap(){
-        motorType = MotorType.Neverest40;
         encoderMotorType = MotorType.Neverest40;
         hardwareMap = new HardwareMap();
         String[] motorNames = new String[] {"back_left_motor", "front_left_motor", "front_right_motor", "back_right_motor"};
-        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(motorType));
+        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(MOTOR_TYPE));
         String[] distNames = new String[]{"front_distance", "left_distance", "back_distance", "right_distance"};
         for (String name: distNames) hardwareMap.put(name, controller.new DistanceSensorImpl());
         //hardwareMap.put("gyro_sensor", controller.new GyroSensorImpl());
@@ -132,7 +131,7 @@ public class EncoderBot extends VirtualBot {
 
         for (int i = 0; i < 4; i++) {
             deltaPos[i] = motors[i].update(millis);
-            w[i] = deltaPos[i] * wheelCircumference / motorType.TICKS_PER_ROTATION;
+            w[i] = deltaPos[i] * wheelCircumference / MOTOR_TYPE.TICKS_PER_ROTATION;
             if (i < 2) w[i] = -w[i];
         }
 

--- a/Controller/src/virtual_robot/controller/robots/classes/MechanumBase.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/MechanumBase.java
@@ -16,7 +16,7 @@ import virtual_robot.util.AngleUtils;
  */
 public class MechanumBase extends VirtualBot {
 
-    public static final MotorType MOTOR_TYPE = MotorType.Neverest40;
+    public final MotorType MOTOR_TYPE;
     private DcMotorExImpl[] motors = null;
     //private VirtualRobotController.GyroSensorImpl gyro = null;
     private BNO055IMUImpl imu = null;
@@ -31,9 +31,20 @@ public class MechanumBase extends VirtualBot {
 
     private double[][] tWR; //Transform from wheel motion to robot motion
 
-
+    /**
+     * No-param constructor. Uses the default motor type of Neverest 40
+     */
     public MechanumBase() {
         super();
+        MOTOR_TYPE = MotorType.Neverest40;
+    }
+
+    public MechanumBase(MotorType driveMotorType){
+        MOTOR_TYPE = driveMotorType;
+    }
+
+    public void initialize(){
+        super.initialize();
         hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl) hardwareMap.get(DcMotorEx.class, "back_left_motor"),

--- a/Controller/src/virtual_robot/controller/robots/classes/MechanumBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/MechanumBot.java
@@ -27,12 +27,13 @@ public class MechanumBot extends MechanumBase {
 
     public MechanumBot() {
         super();
-        hardwareMap.setActive(true);
-        servo = (ServoImpl) hardwareMap.servo.get("back_servo");
-        hardwareMap.setActive(false);
     }
 
     public void initialize() {
+        super.initialize();
+        hardwareMap.setActive(true);
+        servo = (ServoImpl) hardwareMap.servo.get("back_servo");
+        hardwareMap.setActive(false);
         backServoArm.getTransforms().add(new Rotate(0, 37.5, 67.5));
     }
 

--- a/Controller/src/virtual_robot/controller/robots/classes/ProgrammingBoard.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/ProgrammingBoard.java
@@ -33,7 +33,7 @@ import virtual_robot.util.AngleUtils;
 @BotConfig(name = "Programming Board", filename = "programming_board")
 public class ProgrammingBoard extends VirtualBot {
 
-    private MotorType motorType;
+    private MotorType MOTOR_TYPE = MotorType.Neverest40;
     private DcMotorExImpl motor = null;
     private BNO055IMUImpl imu = null;
     private PassiveColorSensorImpl colorSensor = null;
@@ -89,6 +89,11 @@ public class ProgrammingBoard extends VirtualBot {
 
     public ProgrammingBoard(){
         super();
+    }
+
+    public void initialize(){
+        super.initialize();
+
         hardwareMap.setActive(true);
         motor = (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "motor");
         imu = (BNO055IMUImpl) hardwareMap.get(BNO055IMU.class, "imu");
@@ -98,11 +103,7 @@ public class ProgrammingBoard extends VirtualBot {
         analogInput = hardwareMap.get(AnalogInput.class, "pot");
         distanceSensor = (PassiveDistanceSensorImpl)hardwareMap.get(PassiveDistanceSensorImpl.class, "sensor_color_distance");
         hardwareMap.setActive(false);
-        System.out.println("Exiting ProgrammingBoard constructor");
-    }
 
-    public void initialize(){
-        System.out.println("ProgrammingBoard initialize");
         propGroup.getTransforms().add(propGroupRotate);
         servoArmGroup.getTransforms().add(servoArmGroupRotate);
         Bounds boundsInScene = fieldPane.localToScene(fieldPane.getBoundsInLocal());
@@ -115,9 +116,8 @@ public class ProgrammingBoard extends VirtualBot {
     }
 
     protected void createHardwareMap(){
-        motorType = MotorType.Neverest40;
         hardwareMap = new HardwareMap();
-        hardwareMap.put("motor", new DcMotorExImpl(motorType));
+        hardwareMap.put("motor", new DcMotorExImpl(MOTOR_TYPE));
         hardwareMap.put("imu", new BNO055IMUImpl(this, 10));
         hardwareMap.put("sensor_color_distance", new PassiveColorSensorImpl());
         hardwareMap.put("servo", new ServoImpl());

--- a/Controller/src/virtual_robot/controller/robots/classes/QQBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/QQBot.java
@@ -35,11 +35,17 @@ public class QQBot extends TurretBot {
      * Constructor.
      */
     public QQBot() {
-
-        //This call to the superclass constructor is essential. Among other things, this will call the
-        //createHardwareMap() method, so that a HardwareMap object will be available.
         super();
 
+    }
+
+    /**
+     * The initialize() method is called automatically when the robot's graphical UI is loaded from the
+     * arm_bot.fxml markup file. It should be used to set up parts of the graphical UI that will change
+     * as the robot operates
+     */
+    public void initialize() {
+        super.initialize();
         //Temporarily activate the hardware map to allow calls to "get"
         hardwareMap.setActive(true);
 
@@ -54,15 +60,6 @@ public class QQBot extends TurretBot {
         hardwareMap.setActive(false);
 
         gearRatioWheel = 0.5;  // take into account 2:1 reduction from motor
-    }
-
-    /**
-     * The initialize() method is called automatically when the robot's graphical UI is loaded from the
-     * arm_bot.fxml markup file. It should be used to set up parts of the graphical UI that will change
-     * as the robot operates
-     */
-    public void initialize() {
-        super.initialize();
     }
 
     /**
@@ -107,9 +104,6 @@ public class QQBot extends TurretBot {
 
         hardwareMap.put("servo_pivot_shooter", new ServoImpl());
         hardwareMap.put("servo_import_shooter", new ServoImpl());
-        /*
-
-         */
     }
 
     /**

--- a/Controller/src/virtual_robot/controller/robots/classes/QQBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/QQBot.java
@@ -23,7 +23,7 @@ import virtual_robot.controller.BotConfig;
  * combo box. The filename refers to the fxml file that contains the markup for the graphical UI.
  * Note: the fxml file must be located in the virtual_robot.controller.robots.classes.fxml folder.
  */
-@BotConfig(name = "QQ Bot", filename = "QQ_bot")
+@BotConfig(name = "QQ Bot", filename = "qq_bot")
 public class QQBot extends TurretBot {
     // Wobbly goal mechanism
     private ServoImpl grabberServo;
@@ -73,15 +73,27 @@ public class QQBot extends TurretBot {
 
 
         String[] motorNames = new String[]{"back_left_motor", "front_left_motor", "front_right_motor", "back_right_motor"};
+
         hardwareMap.setActive(true);
+        /*
+         * Removing the motors from the dcMotor DeviceMapping removes all trace of them from the HardwareMap (from
+         * the DeviceMapping inner class instance and from the HardwareMap outer class instance). Using the remove method
+         * of HardwareMap directly does not remove them from the DeviceMapping.
+         */
         for (String name : motorNames) {
-            HardwareDevice device = hardwareMap.get(DcMotorEx.class, name);
-            hardwareMap.remove(name, device);
+            hardwareMap.dcMotor.remove(name);
         }
         hardwareMap.setActive(false);
         for (String name : motorNames) hardwareMap.put(name, new DcMotorExImpl(MotorType.Gobilda137));
 
-        hardwareMap.put("color_sensor", controller.new ColorSensorImpl());
+        /*
+         * Note: this will overwrite the ColorSensor object that is already in the HardwareMap from the
+         * MechanumBase class. If your op mode obtains a reference to this new color sensor, it won't function
+         * (because it isn't being updated in the updateStateAndSensors method of QQBot). If you want a second color
+         * sensor, you'd need to use a different name (e.g., "color_sensor_2"), and would then need to handle
+         * updating it in the updateStateAndSensors method.
+         */
+//        hardwareMap.put("color_sensor", controller.new ColorSensorImpl());
 
         hardwareMap.put("grabber", new ServoImpl());
         hardwareMap.put("rotator", new ServoImpl());

--- a/Controller/src/virtual_robot/controller/robots/classes/SwerveBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/SwerveBot.java
@@ -22,7 +22,7 @@ import virtual_robot.util.Vector2D;
 @BotConfig(name = "Swerve Bot", filename = "swerve_bot")
 public class SwerveBot extends VirtualBot {
 
-    MotorType motorType;
+    private final MotorType MOTOR_TYPE = MotorType.Neverest40;
     private DcMotorExImpl[] motors = null;
     private CRServoImpl[] crServos = null;
     private DeadWheelEncoder[] steerEncoders = null;
@@ -55,6 +55,11 @@ public class SwerveBot extends VirtualBot {
 
     public SwerveBot(){
         super();
+    }
+
+    public void initialize(){
+        super.initialize();
+
         hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "back_left_motor"),
@@ -94,23 +99,18 @@ public class SwerveBot extends VirtualBot {
         WHEEL_POS[3] = new Vector2D(interWheelWidth/2, -interWheelLength/2);
 
         hardwareMap.setActive(false);
-        System.out.println("Exiting SwerveBot Constructor");
-    }
 
-    public void initialize(){
-        //backServoArm = (Rectangle)displayGroup.getChildren().get(8);
         backServoArm.getTransforms().add(new Rotate(0, 37.5, 67.5));
     }
 
     protected void createHardwareMap(){
-        motorType = MotorType.Neverest40;
         hardwareMap = new HardwareMap();
         String[] motorNames = new String[] {"back_left_motor", "front_left_motor", "front_right_motor", "back_right_motor"};
         String[] encoderNames = new String[] {"back_left_encoder", "front_left_encoder", "front_right_encoder", "back_right_encoder"};
         String[] crservoNames = new String[] {"back_left_crservo", "front_left_crservo", "front_right_crservo", "back_right_crservo"};
-        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(motorType));
+        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(MOTOR_TYPE));
         for (String name: crservoNames) hardwareMap.put(name, new CRServoImpl(360));
-        for (String name: encoderNames) hardwareMap.put(name, new DeadWheelEncoder(motorType));
+        for (String name: encoderNames) hardwareMap.put(name, new DeadWheelEncoder(MOTOR_TYPE));
         String[] distNames = new String[]{"front_distance", "left_distance", "back_distance", "right_distance"};
         for (String name: distNames) hardwareMap.put(name, controller.new DistanceSensorImpl());
         //hardwareMap.put("gyro_sensor", controller.new GyroSensorImpl());
@@ -145,7 +145,7 @@ public class SwerveBot extends VirtualBot {
             double deltaPos = motors[i].update(millis);
             steerEncoders[i].update(Math.toRadians(crServos[i].updatePositionDegrees(millis)), millis);
             double steer = Math.toRadians(crServos[i].getPositionDegrees());
-            double s = deltaPos * wheelCircumference / motorType.TICKS_PER_ROTATION;
+            double s = deltaPos * wheelCircumference / MOTOR_TYPE.TICKS_PER_ROTATION;
             if (i < 2) s = -s;
             Vector2D w = new Vector2D(-s * Math.sin(steer+headingRadians), s * Math.cos(steer+headingRadians));
             Vector2D v = velocity.added(WHEEL_POS[i].rotated(headingRadians+Math.PI/2).multiplied(omega));

--- a/Controller/src/virtual_robot/controller/robots/classes/TurretBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/TurretBot.java
@@ -56,13 +56,28 @@ public class TurretBot extends MechanumBase {
     private Label elevation;           //Where to put the elevation
 
     /**
-     * Constructor.
+     * No-parameter constructor. This will be used if TurretBot is selected from the Config menu. It will use
+     * the default motor type in MechanumBase.
      */
     public TurretBot() {
-
-        //This call to the superclass constructor is essential. Among other things, this will call the
-        //createHardwareMap() method, so that a HardwareMap object will be available.
         super();
+    }
+
+    /**
+     * TurretBot constructor. This can only be used by subclasses.
+     * @param driveMotorType
+     */
+    public TurretBot(MotorType driveMotorType){
+        super(driveMotorType);
+    }
+
+    /**
+     * The initialize() method is called automatically when the robot's graphical UI is loaded from the
+     * arm_bot.fxml markup file. It should be used to set up parts of the graphical UI that will change
+     * as the robot operates
+     */
+    public void initialize() {
+        super.initialize();
 
         //Temporarily activate the hardware map to allow calls to "get"
         hardwareMap.setActive(true);
@@ -73,14 +88,7 @@ public class TurretBot extends MechanumBase {
 
         //Deactivate the hardwaremap to prevent users from accessing hardware until after INIT is pressed
         hardwareMap.setActive(false);
-    }
 
-    /**
-     * The initialize() method is called automatically when the robot's graphical UI is loaded from the
-     * arm_bot.fxml markup file. It should be used to set up parts of the graphical UI that will change
-     * as the robot operates
-     */
-    public void initialize() {
         turret.getTransforms().add(turretRotate);
     }
 

--- a/Controller/src/virtual_robot/controller/robots/classes/TwoWheelBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/TwoWheelBot.java
@@ -19,7 +19,7 @@ import virtual_robot.util.AngleUtils;
 @BotConfig(name = "Two Wheel Bot", filename = "two_wheel_bot")
 public class TwoWheelBot extends VirtualBot {
 
-    private MotorType motorType;
+    private final MotorType MOTOR_TYPE = MotorType.Neverest40;
     private DcMotorExImpl leftMotor = null;
     private DcMotorExImpl rightMotor = null;
     private GyroSensorImpl gyro = null;
@@ -37,6 +37,11 @@ public class TwoWheelBot extends VirtualBot {
 
     public TwoWheelBot(){
         super();
+    }
+
+    public void initialize(){
+        super.initialize();
+
         hardwareMap.setActive(true);
         leftMotor = (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "left_motor");
         rightMotor = (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "right_motor");
@@ -52,17 +57,14 @@ public class TwoWheelBot extends VirtualBot {
         wheelCircumference = Math.PI * botWidth / 4.5;
         interWheelDistance = botWidth * 8.0 / 9.0;
         hardwareMap.setActive(false);
-    }
 
-    public void initialize(){
         backServoArm.getTransforms().add(new Rotate(0, 37.5, 67.5));
     }
 
     protected void createHardwareMap(){
-        motorType = MotorType.Neverest40;
         hardwareMap = new HardwareMap();
-        hardwareMap.put("left_motor", new DcMotorExImpl(motorType));
-        hardwareMap.put("right_motor", new DcMotorExImpl(motorType));
+        hardwareMap.put("left_motor", new DcMotorExImpl(MOTOR_TYPE));
+        hardwareMap.put("right_motor", new DcMotorExImpl(MOTOR_TYPE));
         String[] distNames = new String[]{"front_distance", "left_distance", "back_distance", "right_distance"};
         for (String name: distNames) hardwareMap.put(name, controller.new DistanceSensorImpl());
         hardwareMap.put("gyro_sensor", new GyroSensorImpl(this, 10));
@@ -73,8 +75,8 @@ public class TwoWheelBot extends VirtualBot {
     public synchronized void updateStateAndSensors(double millis){
         double deltaLeftPos = leftMotor.update(millis);
         double deltaRightPos = rightMotor.update(millis);
-        double leftWheelDist = -deltaLeftPos * wheelCircumference / motorType.TICKS_PER_ROTATION;
-        double rightWheelDist = deltaRightPos * wheelCircumference / motorType.TICKS_PER_ROTATION;
+        double leftWheelDist = -deltaLeftPos * wheelCircumference / MOTOR_TYPE.TICKS_PER_ROTATION;
+        double rightWheelDist = deltaRightPos * wheelCircumference / MOTOR_TYPE.TICKS_PER_ROTATION;
         double distTraveled = (leftWheelDist + rightWheelDist) / 2.0;
         double headingChange = (rightWheelDist - leftWheelDist) / interWheelDistance;
         double deltaRobotX = -distTraveled * Math.sin(headingRadians + headingChange / 2.0);

--- a/Controller/src/virtual_robot/controller/robots/classes/XDriveBot.java
+++ b/Controller/src/virtual_robot/controller/robots/classes/XDriveBot.java
@@ -21,7 +21,7 @@ import virtual_robot.util.AngleUtils;
 @BotConfig(name = "XDrive Bot", filename = "xdrive_bot")
 public class XDriveBot extends VirtualBot {
 
-    MotorType motorType;
+    private final MotorType MOTOR_TYPE = MotorType.Neverest40;
     private DcMotorExImpl[] motors = null;
     //private VirtualRobotController.GyroSensorImpl gyro = null;
     private BNO055IMUImpl imu = null;
@@ -40,6 +40,11 @@ public class XDriveBot extends VirtualBot {
 
     public XDriveBot() {
         super();
+    }
+
+    public void initialize(){
+        super.initialize();
+
         hardwareMap.setActive(true);
         motors = new DcMotorExImpl[]{
                 (DcMotorExImpl)hardwareMap.get(DcMotorEx.class, "back_left_motor"),
@@ -68,18 +73,14 @@ public class XDriveBot extends VirtualBot {
                 {-0.25, 0.25, 0.25, -0.25}
         };
         hardwareMap.setActive(false);
-    }
 
-    public void initialize(){
-        //backServoArm = (Rectangle)displayGroup.getChildren().get(7);
         backServoArm.getTransforms().add(new Rotate(0, 37.5, 67.5));
     }
 
     protected void createHardwareMap(){
-        motorType = MotorType.Neverest40;
         hardwareMap = new HardwareMap();
         String[] motorNames = new String[] {"back_left_motor", "front_left_motor", "front_right_motor", "back_right_motor"};
-        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(motorType));
+        for (String name: motorNames) hardwareMap.put(name, new DcMotorExImpl(MOTOR_TYPE));
         String[] distNames = new String[]{"front_distance", "left_distance", "back_distance", "right_distance"};
         for (String name: distNames) hardwareMap.put(name, controller.new DistanceSensorImpl());
         //hardwareMap.put("gyro_sensor", controller.new GyroSensorImpl());
@@ -94,7 +95,7 @@ public class XDriveBot extends VirtualBot {
 
         for (int i = 0; i < 4; i++) {
             deltaPos[i] = motors[i].update(millis);
-            w[i] = deltaPos[i] * wheelCircumference / motorType.TICKS_PER_ROTATION;
+            w[i] = deltaPos[i] * wheelCircumference / MOTOR_TYPE.TICKS_PER_ROTATION;
             if (i < 2) w[i] = -w[i];
         }
 

--- a/Controller/src/virtual_robot/controller/robots/fxml/qq_bot.fxml
+++ b/Controller/src/virtual_robot/controller/robots/fxml/qq_bot.fxml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.Group?><?import javafx.scene.paint.RadialGradient?><?import javafx.scene.paint.Stop?><?import javafx.scene.shape.Circle?><?import javafx.scene.shape.Rectangle?><?import javafx.scene.control.Label?>
+
+<Group xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1"
+    fx:controller="virtual_robot.controller.robots.classes.QQBot">
+    <children>
+
+        <!--The lowest child objecet is a yellow rectangle measuring 75x75-->
+        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="YELLOW" height="75.0" stroke="BLACK"
+            strokeType="INSIDE" width="75.0" />
+
+        <!--Left back wheel-->
+        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="BLUE" height="20.0" stroke="BLACK"
+            strokeType="INSIDE" width="10.0" y="55.0" />
+
+        <!--Left front wheel-->
+        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="BLUE" height="20.0" stroke="BLACK"
+            strokeType="INSIDE" width="10.0" />
+
+        <!--Right front wheel-->
+        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="BLUE" height="20.0" stroke="BLACK"
+            strokeType="INSIDE" width="10.0" x="65.0" />
+
+        <!--Right back wheel-->
+        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="BLUE" height="20.0" stroke="BLACK"
+            strokeType="INSIDE" width="10.0" x="65.0" y="55.0" />
+
+        <!--Green square indicating the front center of the robot-->
+        <Rectangle arcHeight="5.0" fill="LIME" height="10.0" stroke="BLACK" strokeType="INSIDE"
+            width="10.0" x="32.5" />
+
+        <!--The color sensor-->
+        <Circle centerX="37.0" centerY="37.0" radius="10.0" strokeType="INSIDE" strokeWidth="0.0">
+            <fill>
+                <RadialGradient centerX="0.4722222222222222" centerY="0.4666666666666667"
+                    radius="0.6046511627906976">
+                    <stops>
+                        <Stop color="#3900ff" />
+                        <Stop color="#ff00b6" offset="0.15649563534383953" />
+                        <Stop color="#ff1100" offset="0.32195757791207485" />
+                        <Stop color="#ffee00" offset="0.4880910060433701" />
+                        <Stop color="#18ff00" offset="0.675751471343366" />
+                        <Stop color="#00fffc" offset="0.8281391950073069" />
+                        <Stop color="WHITE" offset="1.0" />
+                    </stops>
+                </RadialGradient>
+            </fill>
+        </Circle>
+
+        <!-- The arm: note the fx:id attribute. This will instantiate a variable named "turret" in the TurretBot class. That
+             variable is of type Rectangle and is annotated with @FXML-->
+        <Rectangle fx:id="turret" arcHeight="5.0" arcWidth="5.0" fill="GRAY" height="35.0"
+            stroke="BLACK" strokeType="INSIDE" width="10.0" x="32.5" y="0.0" />
+        <Label fx:id="elevation" text="15.0" translateX="20.0" translateY="40.0" />
+    </children>
+</Group>


### PR DESCRIPTION
From @c4glenn:  'remove(...)' methods added to HardwareMap and DeviceMapping; these could be used if a subclass developer wants to exclude hardware elements that are included in the superclass. Also a new QQBot config class that extends TurretBot.

Reorganization of setup in bot config classes. Previously, 'createHardwareMap' abstract method (a subclass method) was called from the VirtualBot (superclass) constructor, before variable initialization and contructor execution in the subclass. createHardwareMap is now called from a VirtualBot 'initialize' method; all subclasses have 'initialize' methods, and the first statement in each is 'super.initialize()'. References to hardware devices are now obtained within the 'initialize' methods, rather than the constructors, of the robot configuration classes.



