### PR TITLE
Use liberica-full-17, which includes JavaFX

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">
@@ -14,7 +13,7 @@
   <component name="ProjectKey">
     <option name="state" value="project://e79810c8-c5c8-43b1-b19c-90c1f4095425" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="liberica-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="liberica-full-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>


### PR DESCRIPTION
Currently, the default JDK for the project (specified in .idea/misc.xml) is liberica-17. The regular version of Liberica does not include JavaFX, so a new clone of virtual_robot will not build in IDEA / Android Studio without manually changing the project JDK.
This pull request would change the default JDK to liberica-full-17, which includes JavaFX.